### PR TITLE
Author mode toggle. Better-named defaults. tableauPrefix

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,12 @@
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
 
     <link rel="stylesheet" href="vuegridlayout.css">
+
+    <!-- <link rel="stylesheet" href="https://127.0.0.1:4000/lib/smartdown.css"> -->
+    <!-- <script src="https://127.0.0.1:4000/lib/smartdown.js"></script> -->
+
     <link rel="stylesheet" href="https://unpkg.com/smartdown/docs/lib/smartdown.css">
+    <script src="https://smartdown.site/lib/smartdown.js"></script>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
@@ -15,7 +20,6 @@
     <script src="https://unpkg.com/vue/dist/vue.js"></script>
 
     <script src="https://unpkg.com/vue-grid-layout/dist/vue-grid-layout.min.js"></script>
-    <script src="https://smartdown.site/lib/smartdown.js"></script>
   </head>
 
   <body
@@ -28,8 +32,8 @@
 
         <div
           class="navigationArea">
-          <div class="row">
-            <div class="col-xs-10">
+          <div class="row" v-if="tableaux.length > 0">
+            <div class="col-xs-10" style="padding:0;">
               <button
                 v-for="t in tableaux"
                 class="btn btn-default btn-xs tableau-button"
@@ -40,15 +44,16 @@
               </button>
             </div>
 
-            <div class="col-xs-2">
+            <div class="col-xs-2" style="padding:0;">
               <button
                 class="btn btn-default btn-xs"
                 v-on:click="loadHomeTableau()">
                 Home
               </button>
             </div>
-
-            <div class="col-xs-10">
+          </div>
+          <div class="row">
+            <div class="col-xs-10" style="padding:0;">
               <button
                 v-for="item in tableau.layout.cells"
                 class="btn btn-default btn-xs card-button"
@@ -57,7 +62,7 @@
                 {{item.name}}
               </button>
             </div>
-            <div class="col-xs-2">
+            <div class="col-xs-2" style="padding:0;">
               <button
                 class="btn btn-default btn-xs card-button"
                 v-on:click="focusOnCard('')">
@@ -69,8 +74,11 @@
 
         <div
           v-if="!kioskMode"
-          class="authorArea"
-          @dblclick="toggleAuthorMode()">
+          class="authorArea">
+          <div
+            class="toggle-author-area-button" @click="toggleAuthorMode()">
+            &nbsp;&equiv;&nbsp;
+          </div>
           <div class="row" v-if="authorMode">
             <div class="col-xs-8">
               <input
@@ -161,6 +169,7 @@
 window.gridHelperOptions = {
   kioskMode: false,
   authorMode: false,
+  tableauxPrefix: 'tableaux/',
   tableaux: ['Welcome', 'Comic', 'Gallery', 'WebGL', 'Pegoda'],
   defaultTableauName: 'Welcome',
 };

--- a/vuegridlayout.css
+++ b/vuegridlayout.css
@@ -8,6 +8,19 @@ body.container {
   padding: 0 15px;
 }
 
+.toggle-author-area-button {
+  height:18px;
+  width:16px;
+  font-size:0.9em;
+  margin:-4px 0 -4px -13px;
+  color:darkslateblue;
+  border:1px solid lightgray;
+  border-radius:5px;
+  background:white;
+  cursor:pointer;
+}
+
+
 div#layoutApp {
   background: lightyellow;
   width: 100%;
@@ -19,7 +32,7 @@ div#layoutApp {
 div#layoutApp .navigationArea {
   background: aliceblue;
   width: 100%;
-  padding: 5px 15px;
+  padding: 0 12px;
   margin: 0;
   border: 1px solid lightgray;
   border-radius: 3px;
@@ -158,3 +171,5 @@ div#layoutApp .vue-grid-layout .hide-draggable {
   background: #efefef;
   border-radius: 5px;
 }
+
+


### PR DESCRIPTION
- Adds more visible way to toggle author mode.
- Adjust fitContent() to err on the side of too much vertical height.
- This is a stopgap until we get the proper async dimensions under control.
- Make default values clearly defaultXYZ and used uniformly.
- Allow users of grid_helper.js to specify a tableauPrefix, which will default to the empty string.
